### PR TITLE
fix(deploy): move primary region from deprecated hkg to sin

### DIFF
--- a/.github/workflows/fly-review.yml
+++ b/.github/workflows/fly-review.yml
@@ -7,7 +7,7 @@ on:
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
   # Set these to your Fly.io organization and preferred region.
-  FLY_REGION: hkg
+  FLY_REGION: sin
   FLY_ORG: personal
 
 jobs:

--- a/fly.toml
+++ b/fly.toml
@@ -4,7 +4,7 @@
 #
 
 app = 'moodify-backend-442duw'
-primary_region = 'hkg'
+primary_region = 'sin'
 
 [build]
 


### PR DESCRIPTION
The first auto-deploy (run after merging #17) failed at the migration release command:

> Region hkg is deprecated and cannot have new resources provisioned. Please consider using an alternate region such as sin

Fly can no longer create machines in Hong Kong, so the release-command machine could not launch. This switches `primary_region` in `fly.toml` (and the review-apps region in `fly-review.yml`) to Singapore, per Fly's suggestion.

Everything before the region error worked on the first deploy: token auth, remote image build and push — so merging this should complete the first successful auto-deploy, including migrations.

https://claude.ai/code/session_01Mk6FUEktmFDMxQrSjJNAku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mk6FUEktmFDMxQrSjJNAku)_